### PR TITLE
Implement track

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,6 +3857,11 @@ dependencies = [
 [[package]]
 name = "track"
 version = "0.1.0"
+dependencies = [
+ "avian2d",
+ "bevy",
+ "bevy_reactive_blueprints",
+]
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,13 @@ name = "tagcar"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+debug = []
+
 [dependencies]
 # plugins
-track = { workspace = true }
+track = { workspace = true, features = ["graphics"] }
 
 # bevy
 avian2d = { workspace = true, features = ["debug-plugin"] }

--- a/plugins/track/Cargo.toml
+++ b/plugins/track/Cargo.toml
@@ -3,4 +3,14 @@ name = "track"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+graphics = []
+
 [dependencies]
+avian2d = { workspace = true }
+bevy = { workspace = true }
+bevy_reactive_blueprints = { workspace = true }
+
+[dev-dependencies]
+bevy = { workspace = true, default-features = true }

--- a/plugins/track/src/graphics.rs
+++ b/plugins/track/src/graphics.rs
@@ -1,0 +1,138 @@
+use std::ops::DerefMut;
+
+use bevy::color::palettes;
+use bevy::ecs::system::{StaticSystemParam, SystemParam};
+use bevy::prelude::*;
+
+use bevy_reactive_blueprints::{AsChild, BlueprintPlugin, FromBlueprint};
+
+use crate::{Checkpoint, Track, TrackInterior};
+
+pub struct GraphicsPlugin;
+
+impl Plugin for GraphicsPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(BlueprintPlugin::<Track, TrackGraphicsBundle, AsChild>::default())
+            .add_plugins(BlueprintPlugin::<
+                TrackInterior,
+                TrackInteriorGraphicsBundle,
+                AsChild,
+            >::default())
+            .add_plugins(BlueprintPlugin::<
+                Checkpoint,
+                CheckpointGraphicsBundle,
+                AsChild,
+            >::default());
+    }
+}
+#[derive(SystemParam)]
+pub struct GraphicsAssetsParams<'w> {
+    meshes: ResMut<'w, Assets<Mesh>>,
+    materials: ResMut<'w, Assets<ColorMaterial>>,
+}
+
+#[derive(Bundle)]
+pub struct TrackGraphicsBundle {
+    sprite: ColorMesh2dBundle,
+}
+
+impl TrackGraphicsBundle {
+    pub fn from_track(
+        track: &Track,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<ColorMaterial>,
+    ) -> Self {
+        Self {
+            sprite: ColorMesh2dBundle {
+                material: materials.add(Track::ASPHALT),
+                mesh: meshes
+                    .add(Capsule2d::new(track.radius, track.half_length).mesh())
+                    .into(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl FromBlueprint<Track> for TrackGraphicsBundle {
+    type Params<'w, 's> = GraphicsAssetsParams<'w>;
+
+    fn from_blueprint(track: &Track, params: &mut StaticSystemParam<Self::Params<'_, '_>>) -> Self {
+        let params = params.deref_mut();
+        Self::from_track(track, params.meshes.as_mut(), params.materials.as_mut())
+    }
+}
+
+#[derive(Bundle)]
+pub struct TrackInteriorGraphicsBundle {
+    sprite: ColorMesh2dBundle,
+}
+
+impl TrackInteriorGraphicsBundle {
+    pub fn new(
+        interior: &TrackInterior,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<ColorMaterial>,
+    ) -> Self {
+        Self {
+            sprite: ColorMesh2dBundle {
+                material: materials.add(Track::GRASS),
+                mesh: meshes
+                    .add(Capsule2d::new(interior.radius, interior.half_length).mesh())
+                    .into(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl FromBlueprint<TrackInterior> for TrackInteriorGraphicsBundle {
+    type Params<'w, 's> = GraphicsAssetsParams<'w>;
+
+    fn from_blueprint(
+        interior: &TrackInterior,
+        params: &mut StaticSystemParam<Self::Params<'_, '_>>,
+    ) -> Self {
+        let params = params.deref_mut();
+        Self::new(interior, params.meshes.as_mut(), params.materials.as_mut())
+    }
+}
+
+#[derive(Bundle)]
+pub struct CheckpointGraphicsBundle {
+    sprite: ColorMesh2dBundle,
+}
+
+impl CheckpointGraphicsBundle {
+    pub fn new(
+        checkpoint: &Checkpoint,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<ColorMaterial>,
+    ) -> Self {
+        Self {
+            sprite: ColorMesh2dBundle {
+                material: materials.add(Color::Srgba(palettes::css::WHITE_SMOKE)),
+                mesh: meshes
+                    .add(Rectangle::new(checkpoint.size.x, checkpoint.size.y).mesh())
+                    .into(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl FromBlueprint<Checkpoint> for CheckpointGraphicsBundle {
+    type Params<'w, 's> = GraphicsAssetsParams<'w>;
+
+    fn from_blueprint(
+        checkpoint: &Checkpoint,
+        params: &mut StaticSystemParam<Self::Params<'_, '_>>,
+    ) -> Self {
+        let params = params.deref_mut();
+        Self::new(
+            checkpoint,
+            params.meshes.as_mut(),
+            params.materials.as_mut(),
+        )
+    }
+}

--- a/plugins/track/src/lib.rs
+++ b/plugins/track/src/lib.rs
@@ -1,14 +1,462 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+// TODO: Track plugin using mariokart-style checkpoints and a means
+// of determining lap completion with on-the-fly lap markers
+
+use std::f32::consts::{FRAC_PI_2, PI};
+
+#[cfg(feature = "graphics")]
+use std::ops::DerefMut;
+
+use avian2d::prelude::{Collider, CollisionStarted, RigidBody, Sensor};
+use bevy::color::palettes;
+use bevy::prelude::*;
+use bevy::utils::EntityHashSet;
+use bevy_reactive_blueprints::Blueprint;
+#[cfg(feature = "graphics")]
+use bevy_reactive_blueprints::{AsChild, BlueprintPlugin, FromBlueprint};
+
+pub struct TrackPlugin;
+
+impl Plugin for TrackPlugin {
+    fn build(&self, app: &mut App) {
+        #[cfg(feature = "graphics")]
+        app.add_plugins(BlueprintPlugin::<Track, TrackGraphicsBundle, AsChild>::default())
+            .add_plugins(BlueprintPlugin::<
+                TrackInterior,
+                TrackInteriorGraphicsBundle,
+                AsChild,
+            >::default())
+            .add_plugins(BlueprintPlugin::<
+                Checkpoint,
+                CheckpointGraphicsBundle,
+                AsChild,
+            >::default());
+        app.add_event::<LapComplete>();
+        app.add_systems(
+            Update,
+            (Self::spawn_checkpoints, Self::track_checkpoints)
+                .chain()
+                .in_set(TrackSystems),
+        );
+        app.register_type::<Track>()
+            .register_type::<TrackInterior>()
+            .register_type::<Checkpoint>()
+            .register_type::<Checkpoints>()
+            .register_type::<CheckpointTracker>()
+            .register_type::<LapComplete>();
+    }
 }
+
+impl TrackPlugin {
+    fn spawn_checkpoints(
+        mut commands: Commands,
+        tracks: Query<(Entity, &Track), Without<Checkpoints>>,
+    ) {
+        for (entity, track) in &tracks {
+            let mut checkpoints = vec![];
+            for (position, angle) in track.checkpoints() {
+                let entity = commands
+                    .spawn(Checkpoint::bundle(position, angle, track.thickness))
+                    .id();
+                checkpoints.push(entity);
+            }
+
+            commands.entity(entity).insert(Checkpoints(checkpoints));
+        }
+    }
+
+    fn track_checkpoints(
+        mut collisions: EventReader<CollisionStarted>,
+        mut completed_laps: EventWriter<LapComplete>,
+        mut trackers: Query<&mut CheckpointTracker>,
+        checkpoints: Query<Entity, With<Checkpoint>>,
+    ) {
+        let num_checkpoints = checkpoints.iter().count();
+        for CollisionStarted(entity1, entity2) in collisions.read() {
+            let tracker_entity = if trackers.contains(*entity1) {
+                *entity1
+            } else if trackers.contains(*entity2) {
+                *entity2
+            } else {
+                continue;
+            };
+            let checkpoint_entity = if checkpoints.contains(*entity1) {
+                *entity1
+            } else if checkpoints.contains(*entity2) {
+                *entity2
+            } else {
+                continue;
+            };
+            let mut collision = trackers.get_mut(tracker_entity).unwrap();
+            let checkpoint = checkpoints.get(checkpoint_entity).unwrap();
+            if let Some(lap_complete) =
+                collision.reach_checkpoint(tracker_entity, checkpoint, num_checkpoints)
+            {
+                completed_laps.send(lap_complete);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(SystemSet)]
+pub struct TrackSystems;
+
+#[derive(Clone, Debug)]
+#[derive(Component, Reflect)]
+pub struct Track {
+    half_length: f32,
+    radius: f32,
+    thickness: f32,
+    subdivisions_per_chunk: usize,
+}
+
+impl Default for Track {
+    fn default() -> Self {
+        Self::new(600., 300., 220., 10)
+    }
+}
+
+impl Track {
+    pub const ASPHALT: Color = Color::Srgba(palettes::css::DIM_GRAY);
+    pub const GRASS: Color = Color::Srgba(palettes::css::FOREST_GREEN);
+
+    pub fn new(half_length: f32, radius: f32, thickness: f32, subdivisions: usize) -> Self {
+        Track {
+            half_length,
+            radius,
+            thickness,
+            subdivisions_per_chunk: subdivisions,
+        }
+    }
+
+    pub fn bundle(self) -> impl Bundle {
+        (
+            Blueprint::new(self.clone()),
+            SpatialBundle::from_transform(Transform::from_rotation(Quat::from_rotation_z(
+                FRAC_PI_2,
+            ))),
+            self,
+        )
+    }
+
+    pub fn half_length(&self) -> f32 {
+        self.half_length
+    }
+
+    pub fn radius(&self) -> f32 {
+        self.radius
+    }
+
+    pub fn thickness(&self) -> f32 {
+        self.thickness
+    }
+
+    pub fn checkpoints(&self) -> impl Iterator<Item = (Vec2, f32)> + '_ {
+        // we want to go from
+        //    ---------
+        //   /
+        //  /
+        //  \
+        //   \
+        //    ---------
+        // so we iterate through the "sides" of the track
+        // and flat_map each chunk's subdivisions
+        // etc
+
+        // TrackChunk::Top
+        let y = self.radius;
+        let x = self.half_length - self.radius;
+        let separation = x * 2. / self.subdivisions_per_chunk as f32;
+        let top_chunk_range = (0..=self.subdivisions_per_chunk).map(move |index| {
+            (
+                Vec2::new(x - index as f32 * separation, y - self.thickness / 2.),
+                0.,
+            )
+        });
+
+        let bottom_chunk_range = (0..=self.subdivisions_per_chunk).map(move |index| {
+            (
+                Vec2::new(x - index as f32 * separation, -y + self.thickness / 2.),
+                0.,
+            )
+        });
+
+        // draw N subdivisions on a half circle
+        // x = r * cos(theta), y = r * sin(theta)
+        // on left side, theta in range (pi/2, 3pi/2)
+        let track_center = (self.radius + self.thickness / 4.) / 2.;
+        let left_chunk_range = (1..self.subdivisions_per_chunk).map(move |index| {
+            let theta = FRAC_PI_2 + PI * index as f32 / self.subdivisions_per_chunk as f32;
+            (
+                Vec2::new(-x + track_center * theta.cos(), track_center * theta.sin()),
+                theta - FRAC_PI_2,
+            )
+        });
+        // on right side, theta in range (-pi/2, pi/2)
+        let right_chunk_range = (1..self.subdivisions_per_chunk).map(move |index| {
+            let theta = -FRAC_PI_2 + PI * index as f32 / self.subdivisions_per_chunk as f32;
+            (
+                Vec2::new(x + track_center * theta.cos(), track_center * theta.sin()),
+                theta - FRAC_PI_2,
+            )
+        });
+        top_chunk_range
+            .chain(left_chunk_range)
+            .chain(bottom_chunk_range)
+            .chain(right_chunk_range)
+    }
+}
+
+#[cfg(feature = "graphics")]
+#[derive(Bundle)]
+pub struct TrackGraphicsBundle {
+    sprite: ColorMesh2dBundle,
+}
+
+#[cfg(feature = "graphics")]
+impl TrackGraphicsBundle {
+    pub fn from_track(
+        track: &Track,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<ColorMaterial>,
+    ) -> Self {
+        Self {
+            sprite: ColorMesh2dBundle {
+                material: materials.add(Track::ASPHALT),
+                mesh: meshes
+                    .add(Capsule2d::new(track.radius, track.half_length).mesh())
+                    .into(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[cfg(feature = "graphics")]
+impl FromBlueprint<Track> for TrackGraphicsBundle {
+    type Params<'w, 's> = (ResMut<'w, Assets<Mesh>>, ResMut<'w, Assets<ColorMaterial>>);
+
+    fn from_blueprint(
+        track: &Track,
+        params: &mut bevy::ecs::system::StaticSystemParam<Self::Params<'_, '_>>,
+    ) -> Self {
+        let params = params.deref_mut();
+        Self::from_track(track, params.0.as_mut(), params.1.as_mut())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+#[derive(Component, Reflect)]
+pub struct TrackInterior {
+    radius: f32,
+    half_length: f32,
+}
+
+impl TrackInterior {
+    const Z_INDEX: f32 = 5.;
+
+    pub fn from_track(track: &Track) -> Self {
+        let radius = track.radius - track.thickness;
+        let half_length = track.half_length;
+        Self {
+            radius,
+            half_length,
+        }
+    }
+
+    pub fn bundle(self) -> impl Bundle {
+        (
+            Blueprint::new(self.clone()),
+            RigidBody::Static,
+            Collider::capsule(self.radius, self.half_length),
+            Sensor,
+            SpatialBundle::from_transform(
+                Transform::from_xyz(0., 0., Self::Z_INDEX)
+                    .with_rotation(Quat::from_rotation_z(FRAC_PI_2)),
+            ),
+            self,
+        )
+    }
+}
+
+#[cfg(feature = "graphics")]
+#[derive(Bundle)]
+pub struct TrackInteriorGraphicsBundle {
+    sprite: ColorMesh2dBundle,
+}
+
+#[cfg(feature = "graphics")]
+impl TrackInteriorGraphicsBundle {
+    pub fn new(
+        interior: &TrackInterior,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<ColorMaterial>,
+    ) -> Self {
+        Self {
+            sprite: ColorMesh2dBundle {
+                material: materials.add(Track::GRASS),
+                mesh: meshes
+                    .add(Capsule2d::new(interior.radius, interior.half_length).mesh())
+                    .into(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[cfg(feature = "graphics")]
+impl FromBlueprint<TrackInterior> for TrackInteriorGraphicsBundle {
+    type Params<'w, 's> = (ResMut<'w, Assets<Mesh>>, ResMut<'w, Assets<ColorMaterial>>);
+
+    fn from_blueprint(
+        interior: &TrackInterior,
+        params: &mut bevy::ecs::system::StaticSystemParam<Self::Params<'_, '_>>,
+    ) -> Self {
+        let params = params.deref_mut();
+        Self::new(interior, params.0.as_mut(), params.1.as_mut())
+    }
+}
+
+#[derive(Debug)]
+#[derive(Component, Reflect)]
+pub struct Checkpoint;
+
+impl Checkpoint {
+    const WIDTH: f32 = 4.;
+    const Z_INDEX: f32 = 10.;
+
+    pub fn bundle(position: Vec2, angle: f32, thickness: f32) -> CheckpointBundle {
+        let x = Self::WIDTH;
+        let y = thickness * 1.1;
+        CheckpointBundle {
+            checkpoint: Checkpoint,
+            rigid_body: RigidBody::Static,
+            collider: Collider::rectangle(x, y),
+            sensor: Sensor,
+            spatial: SpatialBundle::from_transform(
+                Transform::from_translation(Vec3::new(position.x, position.y, Self::Z_INDEX))
+                    .with_rotation(Quat::from_rotation_z(angle)),
+            ),
+        }
+    }
+}
+
+#[derive(Bundle)]
+pub struct CheckpointBundle {
+    checkpoint: Checkpoint,
+    rigid_body: RigidBody,
+    collider: Collider,
+    sensor: Sensor,
+    spatial: SpatialBundle,
+}
+
+#[cfg(feature = "graphics")]
+#[derive(Bundle)]
+pub struct CheckpointGraphicsBundle {
+    sprite: ColorMesh2dBundle,
+}
+
+#[cfg(feature = "graphics")]
+impl CheckpointGraphicsBundle {
+    pub fn new(
+        checkpoint: &Checkpoint,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<ColorMaterial>,
+    ) -> Self {
+        Self {
+            sprite: ColorMesh2dBundle {
+                material: materials.add(Color::Srgba(palettes::css::WHITE_SMOKE)),
+                mesh: meshes.add(Rectangle::new(x, y).mesh()).into(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[cfg(feature = "graphics")]
+impl FromBlueprint<TrackInterior> for TrackInteriorGraphicsBundle {
+    type Params<'w, 's> = (ResMut<'w, Assets<Mesh>>, ResMut<'w, Assets<ColorMaterial>>);
+
+    fn from_blueprint(
+        interior: &TrackInterior,
+        params: &mut bevy::ecs::system::StaticSystemParam<Self::Params<'_, '_>>,
+    ) -> Self {
+        let params = params.deref_mut();
+        Self::new(interior, params.0.as_mut(), params.1.as_mut())
+    }
+}
+
+#[derive(Debug)]
+#[derive(Component, Reflect)]
+pub struct Checkpoints(Vec<Entity>);
+
+#[derive(Debug, Default)]
+#[derive(Component, Reflect)]
+pub struct CheckpointTracker {
+    checkpoints: EntityHashSet<Entity>,
+}
+
+impl CheckpointTracker {
+    pub fn reach_checkpoint(
+        &mut self,
+        self_entity: Entity,
+        checkpoint: Entity,
+        expected_total: usize,
+    ) -> Option<LapComplete> {
+        self.checkpoints.insert(checkpoint);
+        if self.checkpoints.len() >= expected_total {
+            Some(LapComplete(self_entity))
+        } else {
+            None
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.checkpoints.clear();
+    }
+}
+
+#[derive(Debug)]
+#[derive(Deref, Event, Reflect)]
+pub struct LapComplete(Entity);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use avian2d::PhysicsPlugins;
+    use bevy::{ecs::system::RunSystemOnce, scene::ScenePlugin};
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((
+            MinimalPlugins,
+            AssetPlugin::default(),
+            ScenePlugin,
+            PhysicsPlugins::default(),
+        ));
+        app.add_plugins(TrackPlugin);
+        app.world_mut().run_system_once(spawn_track_and_tracker);
+        app
+    }
+
+    fn spawn_track_and_tracker(mut commands: Commands) {
+        let track = Track::default();
+        let interior = TrackInterior::from_track(&track);
+        commands.spawn((
+            CheckpointTracker::default(),
+            Collider::rectangle(10., 10.),
+            SpatialBundle::from_transform(Transform::from_xyz(track.half_length, 0., 0.)),
+        ));
+        commands.spawn(interior.bundle());
+        commands.spawn(track.bundle());
+    }
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn test_lap_completion() {
+        let mut app = test_app();
+
+        app.update();
+
+        unimplemented!()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,16 @@
+use avian2d::PhysicsPlugins;
+use bevy::{app::PluginGroupBuilder, prelude::*};
+use bevy_reactive_blueprints::BlueprintsPlugin;
+
+use track::TrackPlugin;
+
+pub struct TagcarPlugins;
+
+impl PluginGroup for TagcarPlugins {
+    fn build(self) -> PluginGroupBuilder {
+        PluginGroupBuilder::start::<Self>()
+            .add_group(PhysicsPlugins::default())
+            .add(BlueprintsPlugin)
+            .add(TrackPlugin)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use avian2d::prelude::*;
 use bevy::prelude::*;
 
 use track::{Track, TrackInterior};
@@ -9,7 +8,8 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins);
     app.add_plugins(TagcarPlugins);
-    app.add_plugins(PhysicsDebugPlugin::default());
+    #[cfg(feature = "debug")]
+    app.add_plugins(avian2d::prelude::PhysicsDebugPlugin::default());
     app.add_systems(Startup, (spawn_camera, spawn_track));
     app.run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,26 @@
+use avian2d::prelude::*;
+use bevy::prelude::*;
+
+use track::{Track, TrackInterior};
+
+use tagcar::TagcarPlugins;
+
 fn main() {
-    println!("Hello, world!");
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins);
+    app.add_plugins(TagcarPlugins);
+    app.add_plugins(PhysicsDebugPlugin::default());
+    app.add_systems(Startup, (spawn_camera, spawn_track));
+    app.run();
+}
+
+fn spawn_camera(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+}
+
+fn spawn_track(mut commands: Commands) {
+    let track = Track::default();
+    let interior = TrackInterior::from_track(&track);
+    commands.spawn(interior.bundle());
+    commands.spawn(track.bundle());
 }


### PR DESCRIPTION
Implements a track and checkpoints to help track progress as well as power the zamboni.

A test provides example usage and shows that the checkpoints correctly:
1) fire a `LapComplete` event and
2) clear the checkpoint buffer
whenever all checkpoints have been passed through.

It does not yet check for false positives or anything like that.