### PR TITLE
Implement tag mechanics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "laptag"
+version = "0.1.0"
+dependencies = [
+ "avian2d",
+ "bevy",
+ "track",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/plugins/laptag/Cargo.toml
+++ b/plugins/laptag/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "laptag"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+avian2d = { workspace = true }
+bevy = { workspace = true, features = ["bevy_pbr"] }
+track = { workspace = true }

--- a/plugins/laptag/src/lib.rs
+++ b/plugins/laptag/src/lib.rs
@@ -1,0 +1,90 @@
+use avian2d::prelude::CollisionStarted;
+use bevy::prelude::*;
+use track::{CheckpointTracker, LapComplete};
+
+pub struct LapTagPlugin;
+
+impl Plugin for LapTagPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (
+                Self::transfer_tag,
+                Self::reset_lap_on_tag,
+                Self::score_completed_laps,
+            )
+                .chain()
+                .in_set(LapTagSystems),
+        );
+        app.register_type::<Score>()
+            .register_type::<TagIt>()
+            .register_type::<CanBeIt>();
+    }
+}
+
+impl LapTagPlugin {
+    fn transfer_tag(
+        mut commands: Commands,
+        mut collisions: EventReader<CollisionStarted>,
+        tag_its: Query<Entity, With<TagIt>>,
+        can_be_its: Query<Entity, (With<CanBeIt>, Without<TagIt>)>,
+    ) {
+        for CollisionStarted(entity1, entity2) in collisions.read() {
+            let entity1_is_it = tag_its.contains(*entity1);
+            let entity2_is_it = tag_its.contains(*entity2);
+            let entity1_can_be_it = can_be_its.contains(*entity1);
+            let entity2_can_be_it = can_be_its.contains(*entity2);
+            let (it_entity, tagged_entity) = if entity1_is_it && !entity2_is_it && entity2_can_be_it
+            {
+                (*entity1, *entity2)
+            } else if entity2_is_it && !entity1_is_it && entity1_can_be_it {
+                (*entity2, *entity1)
+            } else {
+                continue;
+            };
+            commands.entity(it_entity).remove::<TagIt>();
+            commands.entity(tagged_entity).insert(TagIt);
+        }
+    }
+
+    fn reset_lap_on_tag(
+        mut lap_trackers: Query<&mut CheckpointTracker>,
+        new_tag_its: Query<Entity, Added<TagIt>>,
+        mut removed_tag_its: RemovedComponents<TagIt>,
+    ) {
+        for entity in new_tag_its.iter().chain(removed_tag_its.read()) {
+            let Ok(mut tracker) = lap_trackers.get_mut(entity) else {
+                continue;
+            };
+            tracker.clear();
+        }
+    }
+
+    fn score_completed_laps(
+        mut completed_laps: EventReader<LapComplete>,
+        mut scores: Query<&mut Score, (With<TagIt>, With<CheckpointTracker>)>,
+    ) {
+        for lap in completed_laps.read() {
+            let Ok(mut score) = scores.get_mut(lap.racer) else {
+                continue;
+            };
+            **score += 1;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(SystemSet)]
+pub struct LapTagSystems;
+
+#[derive(Clone, Copy, Debug)]
+#[derive(Component, Deref, DerefMut, Reflect)]
+pub struct Score(u32);
+
+#[derive(Clone, Copy, Debug)]
+#[derive(Component, Reflect)]
+pub struct TagIt;
+
+#[derive(Clone, Copy, Debug)]
+#[derive(Component, Reflect)]
+pub struct CanBeIt;

--- a/plugins/track/src/lib.rs
+++ b/plugins/track/src/lib.rs
@@ -290,7 +290,7 @@ impl CheckpointTracker {
         self.checkpoints.insert(checkpoint);
         if self.checkpoints.len() >= expected_total {
             self.clear();
-            Some(LapComplete(self_entity))
+            Some(LapComplete { racer: self_entity })
         } else {
             None
         }
@@ -311,7 +311,9 @@ impl CheckpointTracker {
 
 #[derive(Debug)]
 #[derive(Deref, Event, Reflect)]
-pub struct LapComplete(Entity);
+pub struct LapComplete {
+    pub racer: Entity,
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Two versions of tag which can be spawned on individual racers and can exist simultaneously. In all versions, tagging a player transfers tag and resets the lap tracker. If a lap is completed without transferring the tag, a command is fired, as follows:

- "scoring" it: adds +1 to a score counter
- "bomb" it: destroys the entity